### PR TITLE
Possible fix for excessive movement calculation when moving a unit with BA attached.

### DIFF
--- a/StrategicOperations/StrategicOperations/Framework/Utils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/Utils.cs
@@ -22,11 +22,11 @@ namespace StrategicOperations.Framework
         {
             actor.CurrentPosition = newPosition;
             actor.GameRep.transform.position = newPosition;
-            //actor.OnPositionUpdate(newPosition, actor.CurrentRotation, -1, true, null, false);
-            //actor.previousPosition = newPosition;
+            actor.OnPositionUpdate(newPosition, actor.CurrentRotation, -1, true, null, false);
+            actor.previousPosition = newPosition;
             //actor.ResetPathing(false);
             //actor.RebuildPathingForNoMovement();
-            //actor.IsTeleportedOffScreen = false;
+            actor.IsTeleportedOffScreen = false;
         }
         public static void ActivateSpawnTurretFromActor(this Ability __instance, AbstractActor creator, Team team, Vector3 positionA, Vector3 positionB)
         {

--- a/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
@@ -679,7 +679,7 @@ namespace StrategicOperations.Patches
                         {
                             pos = __instance.owningActor.CurrentPosition + Vector3.down * trackerInfo.Value.Offset +
                                   Vector3.up * mech.custGameRep.HeightController.CurrentHeight;
-                            targetActor.TeleportActor(pos);
+                            targetActor.TeleportActorVisual(pos);
                             if (targetActor is CustomMech customMech)
                             {
                                 customMech.custGameRep.j_Root.localRotation = Quaternion.identity;
@@ -692,7 +692,7 @@ namespace StrategicOperations.Patches
                         else
                         {
                             pos = __instance.owningActor.CurrentPosition + Vector3.down * trackerInfo.Value.Offset;
-                            targetActor.TeleportActor(pos);
+                            targetActor.TeleportActorVisual(pos);
                             if (targetActor is CustomMech customMech)
                             {
                                 customMech.custGameRep.j_Root.localRotation = Quaternion.identity;
@@ -724,11 +724,11 @@ namespace StrategicOperations.Patches
                         {
                             pos = __instance.owningActor.CurrentPosition +
                                   Vector3.up * mech.custGameRep.HeightController.CurrentHeight;
-                            targetActor.TeleportActor(pos);
+                            targetActor.TeleportActorVisual(pos);
                         }
                         else
                         {
-                            targetActor.TeleportActor(__instance.owningActor.CurrentPosition);
+                            targetActor.TeleportActorVisual(__instance.owningActor.CurrentPosition);
                         }
 
                         targetActor.MountedEvasion(__instance.owningActor);
@@ -748,7 +748,7 @@ namespace StrategicOperations.Patches
                     {
                         var targetActor = combat.FindActorByGUID(targetActorGUID.Key);
                         if (targetActor == null) continue;
-                        targetActor.TeleportActor(__instance.owningActor.CurrentPosition);
+                        targetActor.TeleportActorVisual(__instance.owningActor.CurrentPosition);
                         targetActor.MountedEvasion(__instance.owningActor);
                         ModInit.modLog?.Debug?.Write(
                             $"[OrderSequence_OnUpdate] PositionLockMount- Setting riding unit {targetActor.DisplayName} position to same as carrier unit {__instance.owningActor.DisplayName}");
@@ -940,11 +940,11 @@ namespace StrategicOperations.Patches
                         {
                             pos = __instance.OwningMech.CurrentPosition +
                                   Vector3.up * mech.custGameRep.HeightController.CurrentHeight;
-                            targetActor.TeleportActor(pos);
+                            targetActor.TeleportActorVisual(pos);
                         }
                         else
                         {
-                            targetActor.TeleportActor(__instance.OwningMech.CurrentPosition);
+                            targetActor.TeleportActorVisual(__instance.OwningMech.CurrentPosition);
                         }
 
                         targetActor.MountedEvasion(__instance.OwningMech);


### PR DESCRIPTION
We don't need to clear pathing because the BA is attached to the moving unit which already does that.

Added the Visual teleport to a few more places, there may be more associated with carried vehicles/mechs, not sure.